### PR TITLE
Synchronizer improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Contao application (4.8+) and display them as native content.
     You can pass an account's id or description as a parameter to only sync
     this one account and `--dry-run` to only see what would be updated without
     persisting the changes. Use the option `--purge` to clear the database
-    table completely beforehand.
-    
+    table and all downloaded files completely beforehand.
+
  4. If you also want to import attachments, set up a cron job that executes
     the `immoscout24:scrape-attachments` command afterwards.  
  
@@ -105,3 +105,6 @@ It allows passing in an image size configuration:
   // ... or define your own
   echo $attachment->render($myImageSizeConfiguration);
 ``` 
+
+Keep in mind, that the attachment owns the referenced file. This means: Once the
+attachment is deleted the file will be gone as well.

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ Contao application (4.8+) and display them as native content.
 
 ### Setup
  1. Install the bundle and update your database. There is no further
-    configuration necessary.    
+    configuration necessary.
     ```bash
     composer require derhaeuptling/contao-immobilienscout24-import-bundle
     ```
- 
+
  2. Add at least one `Immoscout24 Account` in the backend and enter your API
     credentials.
-    
+
  3. Setup a cron job that executes the `immoscout24:sync` command or run it
     yourself to import real estate objects from the API into your application.
     You can pass an account's id or description as a parameter to only sync
@@ -29,18 +29,18 @@ Contao application (4.8+) and display them as native content.
     table and all downloaded files completely beforehand.
 
  4. If you also want to import attachments, set up a cron job that executes
-    the `immoscout24:scrape-attachments` command afterwards.  
- 
+    the `immoscout24:scrape-attachments` command afterwards.
+
  5. Add one or more Immoscout24 modules in your theme and use it in the frontend:
     - The **Real estate list** displays a list of real estate objects. If you
       want to generate a teaser list with 'read more' links, make sure to
-      specify a 'jump to' page with the appropriate reader. 
-            
+      specify a 'jump to' page with the appropriate reader.
+
     - The **Real estate reader** displays a single real estate object based on
       the url parameter (id).
-      
+
     - List items can be constrained individually by using a filter expression.
-      
+
 
 ### Templates and values
 The real estate listings contain lots of fields - most likely you'll want to
@@ -48,25 +48,25 @@ adapt the templates to your needs and only output some of the fields. To do
 this, there are some helpers for your convenience.
 
 A) Real estate data comes in the form of an **entity instance**, you can type hint
-against it to get IDE auto-completion in your templates: 
+against it to get IDE auto-completion in your templates:
 ```php
   /** var Derhaeuptling\ContaoImmoscout24\Entity\RealEstate $realEstate */
   $realEstate
-```  
+```
 
 B) You can also obtain a **list of all available attributes**:
 ```php
   $this->attributes
 
-  // array [name => label] of publicly accessible fields of the real estate objects 
+  // array [name => label] of publicly accessible fields of the real estate objects
   // e.g. 'descriptionNote' that can be accessed via $realEstate->descriptionNote
 ```
-    
-C) To **retrieve and format data**, you can use these helper functions:    
+
+C) To **retrieve and format data**, you can use these helper functions:
 ```php
   $this->hasData(RealEstate $realEstate, string $attribute) : bool
-  // will return wether $realEstate holds data for the $attribute 
-         
+  // will return wether $realEstate holds data for the $attribute
+
   $this->getFormatted(RealEstate $realEstate, string $attribute) : string
   // will return the formatted value of $attribute - enumerations, dates and
   // booleans will resolved to a string representation based on the language
@@ -74,7 +74,7 @@ C) To **retrieve and format data**, you can use these helper functions:
 ```
 
 D) If you want to resolve enumerations yourself you can find all of them as
-public constants in the `RealEstate` entity. 
+public constants in the `RealEstate` entity.
 
 Some enumeration values can occur multiple times per value. In this case
 they are implemented as binary flags:
@@ -89,7 +89,7 @@ they are implemented as binary flags:
   $value = -(FLAG__TYPE_A | FLAG__TYPE_E); // = 17
 ```
 Note that flagged values are stored as **negative numbers**, so that they can
-easily be differentiated from regular enumeration values. 
+easily be differentiated from regular enumeration values.
 
 ### Attachments
 Real estate objects can have multiple attachments. Note: that currently only images
@@ -101,10 +101,10 @@ It allows passing in an image size configuration:
   // use the settings from the modules ...
   echo $attachment->render($this->defaultImageSize);
   echo $attachment->render($this->alternativeImageSize);
- 
+
   // ... or define your own
   echo $attachment->render($myImageSizeConfiguration);
-``` 
+```
 
 Keep in mind, that the attachment owns the referenced file. This means: Once the
 attachment is deleted the file will be gone as well.

--- a/src/Entity/Attachment.php
+++ b/src/Entity/Attachment.php
@@ -128,6 +128,20 @@ class Attachment extends DcaDefault
         $this->projectDir = $projectDir;
     }
 
+    public function getTargetIdentifier(): string
+    {
+        return md5($this->getScrapingUrl() ?? '');
+    }
+
+    public function update(self $newVersion): void
+    {
+        $this->createdAt = $newVersion->createdAt;
+        $this->modifiedAt = $newVersion->modifiedAt;
+        $this->title = $newVersion->title;
+        $this->isFloorPlan = $newVersion->isFloorPlan;
+        $this->isTitlePicture = $newVersion->isTitlePicture;
+    }
+
     /**
      * Get the attachment state.
      */
@@ -173,7 +187,8 @@ class Attachment extends DcaDefault
 
     public function getScrapingUrl(): ?string
     {
-        $urlCandidates = StringUtil::deserialize(stream_get_contents($this->scraperUrls), true);
+        $data = \is_resource($this->scraperUrls) ? stream_get_contents($this->scraperUrls) : $this->scraperUrls;
+        $urlCandidates = StringUtil::deserialize($data, true);
 
         if (empty($urlCandidates)) {
             return null;
@@ -204,6 +219,11 @@ class Attachment extends DcaDefault
     public function getRealEstate(): RealEstate
     {
         return $this->realEstate;
+    }
+
+    public function setRealEstate(RealEstate $realEstate): void
+    {
+        $this->realEstate = $realEstate;
     }
 
     /**

--- a/src/Entity/RealEstate.php
+++ b/src/Entity/RealEstate.php
@@ -1283,6 +1283,11 @@ class RealEstate extends DcaDefault
         $this->attachments = new ArrayCollection();
     }
 
+    public function __toString(): string
+    {
+        return "realEstate#{$this->realEstateId}";
+    }
+
     /**
      * @throws AnnotationException
      *

--- a/src/Entity/RealEstate.php
+++ b/src/Entity/RealEstate.php
@@ -1269,7 +1269,7 @@ class RealEstate extends DcaDefault
     private $immoscoutAccount;
 
     /**
-     * @ORM\OneToMany(targetEntity="Derhaeuptling\ContaoImmoscout24\Entity\Attachment", mappedBy="realEstate", cascade={"persist", "remove"})
+     * @ORM\OneToMany(targetEntity="Derhaeuptling\ContaoImmoscout24\Entity\Attachment", mappedBy="realEstate", cascade={"persist", "remove"}, orphanRemoval=true)
      *
      * @var Collection|Attachment[]
      */

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -39,7 +39,8 @@ services:
         arguments:
             - '@Derhaeuptling\ContaoImmoscout24\Synchronizer\SynchronizerFactory'
             - '@Derhaeuptling\ContaoImmoscout24\Repository\AccountRepository'
-            - '@database_connection'
+            - '@Derhaeuptling\ContaoImmoscout24\Repository\RealEstateRepository'
+            - '@doctrine.orm.entity_manager'
         tags:
             - { name: 'console.command', command: 'immoscout24:sync' }
 

--- a/src/Synchronizer/Synchronizer.php
+++ b/src/Synchronizer/Synchronizer.php
@@ -83,6 +83,8 @@ class Synchronizer
         } catch (PermissionDeniedException $e) {
             $this->output(" > <error>API access for account '{$this->account->getDescription()}' failed: '{$e->getMessage()}'</error>");
 
+            restore_error_handler();
+
             return false;
         }
 
@@ -166,6 +168,8 @@ class Synchronizer
         $this->entityManager->commit();
 
         $this->output(" > Done - created: $created | updated: $updated | removed: $removed");
+
+        restore_error_handler();
 
         return true;
     }

--- a/src/Synchronizer/Synchronizer.php
+++ b/src/Synchronizer/Synchronizer.php
@@ -128,7 +128,7 @@ class Synchronizer
             }
 
             try {
-                $apiItem->mergeInto($localItem, $this->entityManager);
+                $localItem->update($apiItem);
                 ++$updated;
 
                 $this->output(


### PR DESCRIPTION
This implements/fixes:
* use of doctrine's deprecated/removed `EntityManager#detach` and `EntityManager#merge` functionality and instead implements explicit synchronization including attachments (keeping existing alive and updating instead)
* orphan removal of attachments
* attachment file ownership (= deleting file when deleting attachment)

This also improves the purging option because tracked files are now purged as well.