### PR TITLE
Increase wait_timeout and interactive_timeout (MySQL)

### DIFF
--- a/src/Synchronizer/Synchronizer.php
+++ b/src/Synchronizer/Synchronizer.php
@@ -60,6 +60,12 @@ class Synchronizer
             $this->output(" ! <error>$message</error>");
         });
 
+        // prevent mysql server from closing the connection prematurely
+        $this->entityManager
+            ->getConnection()
+            ->exec('SET SESSION wait_timeout = 28000, interactive_timeout = 28800')
+        ;
+
         // gather data from API
         $this->output("\n<comment>[{$this->account->getDescription()}]</comment>\n");
         $this->output(' > Importing from API...');


### PR DESCRIPTION
Increase MySQL's  `wait_timeout` and `interactive_timeout` when synchronizing.

This prevents closing the connection prematurely if a hoster has a low number set for mysql via php (e.g. 60s). The default value is `28000` (8 hours).