### PR TITLE
Allow creating access token credentials from within the back end

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,10 @@
     "doctrine/annotations": "^1.6",
     "doctrine/doctrine-bundle": "^1.8 || ^2.0",
     "symfony/expression-language": "^4.3 || ^5.3",
+    "symfony/security-bundle": "^4.3 || ^5.3",
     "codefog/contao-haste": "^4.9",
-    "webmozart/path-util": "^2.3"
+    "webmozart/path-util": "^2.3",
+    "league/oauth1-client": "^1.10"
   },
   "require-dev": {
     "contao/manager-plugin": "^2.0",

--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -17,10 +17,13 @@ use Contao\ManagerPlugin\Bundle\BundlePluginInterface;
 use Contao\ManagerPlugin\Bundle\Config\BundleConfig;
 use Contao\ManagerPlugin\Bundle\Parser\ParserInterface;
 use Contao\ManagerPlugin\Config\ConfigPluginInterface;
+use Contao\ManagerPlugin\Routing\RoutingPluginInterface;
 use Derhaeuptling\ContaoImmoscout24\DerhaeuptlingContaoImmobilienscout24Bundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\Config\Loader\LoaderResolverInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
 
-class Plugin implements BundlePluginInterface, ConfigPluginInterface
+class Plugin implements BundlePluginInterface, RoutingPluginInterface, ConfigPluginInterface
 {
     /**
      * {@inheritdoc}
@@ -31,6 +34,17 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface
             BundleConfig::create(DerhaeuptlingContaoImmobilienscout24Bundle::class)
                 ->setLoadAfter([ContaoCoreBundle::class]),
         ];
+    }
+
+    public function getRouteCollection(LoaderResolverInterface $resolver, KernelInterface $kernel)
+    {
+        $file = '@DerhaeuptlingContaoImmobilienscout24Bundle/Resources/config/routing.yaml';
+
+        if (false === $loader = $resolver->resolve($file)) {
+            throw new \RuntimeException('Could not load routing configuration.');
+        }
+
+        return $loader->load($file);
     }
 
     /**

--- a/src/Controller/BackEnd/AccessTokenController.php
+++ b/src/Controller/BackEnd/AccessTokenController.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Immobilienscout24 bundle for Contao Open Source CMS
+ *
+ * @copyright  Copyright © derhaeuptling (https://derhaeuptling.com/)
+ * @author     Moritz Vondano
+ * @license    MIT
+ */
+
+namespace Derhaeuptling\ContaoImmoscout24\Controller\BackEnd;
+
+use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\Translation\Translator;
+use Contao\Message;
+use Derhaeuptling\ContaoImmoscout24\Entity\Account;
+use Derhaeuptling\ContaoImmoscout24\OAuth\Server;
+use Derhaeuptling\ContaoImmoscout24\Repository\AccountRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use League\OAuth1\Client\Credentials\CredentialsException;
+use League\OAuth1\Client\Credentials\TemporaryCredentials;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Core\Security;
+use System;
+
+class AccessTokenController extends AbstractController
+{
+    public const SESSION_KEY__TEMPORARY_CREDENTIALS = 'immoscout24.temporary_credentials';
+    public const SESSION_KEY__ACCOUNT = 'immoscout24.account';
+    public const SESSION_KEY__BASE_URI = 'immoscout24.base_uri';
+
+    /** @var Security */
+    private $security;
+
+    /** @var AccountRepository */
+    private $accountRepository;
+
+    /** @var EntityManagerInterface */
+    private $entityManager;
+
+    /** @var Translator */
+    private $translator;
+
+    /** @var ContaoFramework */
+    private $framework;
+
+    public function __construct(Security $security, AccountRepository $accountRepository, EntityManagerInterface $entityManager, Translator $translator, ContaoFramework $framework)
+    {
+        $this->security = $security;
+        $this->accountRepository = $accountRepository;
+        $this->entityManager = $entityManager;
+        $this->translator = $translator;
+        $this->framework = $framework;
+    }
+
+    /**
+     * @Route("_immoscout24/confirm",
+     *     name="immoscout24_confirm",
+     *     defaults={
+     *          "_scope" = "backend",
+     *          "_token_check" = true,
+     *     }
+     * )
+     */
+    public function generateToken(Request $request): Response
+    {
+        if (!$this->security->isGranted('ROLE_USER')) {
+            throw $this->createAccessDeniedException();
+        }
+
+        if (!$request->query->has('oauth_token') || !$request->query->has('oauth_verifier')) {
+            return new Response('Missing OAuth token/verifier information.', Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+
+        // Retrieve process information from session
+        if (!$request->hasSession()) {
+            throw new \RuntimeException('Could not access session.');
+        }
+
+        $session = $request->getSession();
+
+        $temporaryCredentials = unserialize(
+            $session->get(self::SESSION_KEY__TEMPORARY_CREDENTIALS),
+            ['allowed_classes' => [TemporaryCredentials::class]]
+        );
+
+        if (!$temporaryCredentials instanceof TemporaryCredentials) {
+            throw new \RuntimeException('Could not fetch temporary credentials.');
+        }
+
+        $accountId = $session->get(self::SESSION_KEY__ACCOUNT);
+
+        if (null === ($account = $this->accountRepository->find($accountId))) {
+            return new Response('No associated account was found.', Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+
+        // Update entity
+        $this->updateTokenCredentials(
+            $account,
+            $temporaryCredentials,
+            $request->query->get('oauth_token'),
+            $request->query->get('oauth_verifier')
+        );
+
+        // Clean up session
+        $session->remove(self::SESSION_KEY__TEMPORARY_CREDENTIALS);
+        $session->remove(self::SESSION_KEY__ACCOUNT);
+        $baseUri = $session->remove(self::SESSION_KEY__BASE_URI);
+
+        // Redirect back
+        return new RedirectResponse($baseUri);
+    }
+
+    private function updateTokenCredentials(Account $account, TemporaryCredentials $temporaryCredentials, string $oAuthToken, string $oAuthVerifier): void
+    {
+        // Make sure language files are loaded before adding flash messages
+        $this->framework->initialize();
+        System::loadLanguageFile('tl_immoscout24_account');
+
+        $accountCredentials = $account->getCredentials();
+
+        $server = new Server(
+            $accountCredentials->getConsumerKey(),
+            $accountCredentials->getConsumerSecret()
+        );
+
+        // Get token credentials from server
+        try {
+            $tokenCredentials = $server->getTokenCredentials($temporaryCredentials, $oAuthToken, $oAuthVerifier);
+        } catch (CredentialsException $e) {
+            Message::addError(
+                $this->translator->trans('tl_immoscout24_account.access_token_error_2', [], 'contao_default')
+            );
+
+            return;
+        }
+
+        // Persist changes to account
+        $accountCredentials->setAccessTokenCredentials($tokenCredentials);
+        $this->entityManager->flush();
+
+        Message::addInfo(
+            $this->translator->trans('tl_immoscout24_account.access_token_success', [], 'contao_default')
+        );
+    }
+}

--- a/src/Entity/Credentials.php
+++ b/src/Entity/Credentials.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Derhaeuptling\ContaoImmoscout24\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use League\OAuth1\Client\Credentials\TokenCredentials;
 
 /**
  * @ORM\Embeddable()
@@ -73,5 +74,11 @@ class Credentials
     public function getAccessTokenSecret(): string
     {
         return $this->accessTokenSecret;
+    }
+
+    public function setAccessTokenCredentials(TokenCredentials $tokenCredentials): void
+    {
+        $this->accessToken = $tokenCredentials->getIdentifier();
+        $this->accessTokenSecret = $tokenCredentials->getSecret();
     }
 }

--- a/src/OAuth/Server.php
+++ b/src/OAuth/Server.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Immobilienscout24 bundle for Contao Open Source CMS
+ *
+ * @copyright  Copyright © derhaeuptling (https://derhaeuptling.com/)
+ * @author     Moritz Vondano
+ * @license    MIT
+ */
+
+namespace Derhaeuptling\ContaoImmoscout24\OAuth;
+
+use League\OAuth1\Client\Credentials\TemporaryCredentials;
+use League\OAuth1\Client\Credentials\TokenCredentials;
+use League\OAuth1\Client\Server\Server as BaseServer;
+
+class Server extends BaseServer
+{
+    /** @var string */
+    private $domain = 'immobilienscout24.de';
+
+    /** @var string|null */
+    private $verifier;
+
+    public function __construct(string $key, string $secret, string $callbackUri = null)
+    {
+        parent::__construct([
+            'identifier' => $key,
+            'secret' => $secret,
+            'callback_uri' => $callbackUri,
+        ]);
+    }
+
+    public function urlTemporaryCredentials(): string
+    {
+        return "https://rest.$this->domain/restapi/security/oauth/request_token";
+    }
+
+    public function urlAuthorization(): string
+    {
+        return "https://rest.$this->domain/restapi/security/oauth/confirm_access";
+    }
+
+    public function urlTokenCredentials(): string
+    {
+        return "https://rest.$this->domain/restapi/security/oauth/access_token";
+    }
+
+    public function urlUserDetails(): void
+    {
+        throw new \RuntimeException('not implemented');
+    }
+
+    public function userDetails($data, TokenCredentials $tokenCredentials): void
+    {
+        throw new \RuntimeException('not implemented');
+    }
+
+    public function userUid($data, TokenCredentials $tokenCredentials): void
+    {
+        throw new \RuntimeException('not implemented');
+    }
+
+    public function userEmail($data, TokenCredentials $tokenCredentials): void
+    {
+        throw new \RuntimeException('not implemented');
+    }
+
+    public function userScreenName($data, TokenCredentials $tokenCredentials): void
+    {
+        throw new \RuntimeException('not implemented');
+    }
+
+    public function getTokenCredentials(TemporaryCredentials $temporaryCredentials, $temporaryIdentifier, $verifier): TokenCredentials
+    {
+        // Make verifier available during processing
+        $this->verifier = $verifier;
+
+        $credentials = parent::getTokenCredentials($temporaryCredentials, $temporaryIdentifier, $verifier);
+
+        $this->verifier = null;
+
+        return $credentials;
+    }
+
+    /**
+     * Immoscout24 relies on the 'oauth_verifier' also being part of the
+     * 'Authorization' header, so we need to adjust the protocol headers.
+     */
+    protected function additionalProtocolParameters(): array
+    {
+        return null === $this->verifier ? [] : [
+            'oauth_verifier' => $this->verifier,
+        ];
+    }
+}

--- a/src/Resources/config/routing.yaml
+++ b/src/Resources/config/routing.yaml
@@ -1,0 +1,3 @@
+immoscout24:
+  resource: '../../Controller/'
+  type: annotation

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -64,6 +64,8 @@ services:
         arguments:
             - '@Derhaeuptling\ContaoImmoscout24\Repository\AccountRepository'
             - '@contao.translation.translator'
+            - '@request_stack'
+            - '@router'
         tags:
             - { name: 'terminal42_service_annotation' }
 
@@ -73,6 +75,18 @@ services:
             - '@Derhaeuptling\ContaoImmoscout24\ExpressionLanguage\RealEstateFilterEvaluator'
         tags:
             - { name: 'terminal42_service_annotation' }
+
+    Derhaeuptling\ContaoImmoscout24\Controller\BackEnd\AccessTokenController:
+        public: true
+        arguments:
+            - '@security.helper'
+            - '@Derhaeuptling\ContaoImmoscout24\Repository\AccountRepository'
+            - '@doctrine.orm.entity_manager'
+            - '@contao.translation.translator'
+            - '@contao.framework'
+
+        calls:
+            - [setContainer, ['@service_container']]
 
     # frontend
     Derhaeuptling\ContaoImmoscout24\Controller\FrontendModule\RealEstateListController:

--- a/src/Resources/contao/dca/tl_immoscout24_account.php
+++ b/src/Resources/contao/dca/tl_immoscout24_account.php
@@ -76,8 +76,9 @@ $GLOBALS['TL_DCA']['tl_immoscout24_account'] =
         'palettes' => [
             '__selector__' => [],
             'default' => '{basic_legend},description;'.
-                '{credentials_legend},api_explanation,api_consumer_key,api_consumer_secret,api_access_token,api_access_token_secret;'.
-                '{sync_legend},enabled;', // . '{media_legend},upload_directory;',
+                '{credentials_legend},api_explanation,api_consumer_key,api_consumer_secret;'.
+                '{token_legend},api_access_token,api_access_token_secret,token_explanation,provision_access_token;'.
+                '{sync_legend},enabled;',
         ],
 
         // Subpalettes
@@ -96,12 +97,32 @@ $GLOBALS['TL_DCA']['tl_immoscout24_account'] =
             ],
             'api_explanation' => [
                 'exclude' => true,
-                'input_field_callback' => static function (Contao\DataContainer $dc) {
+                'input_field_callback' => static function () {
                     return sprintf(
-                        '<div class="widget"><p class="tl_info">%s</p></div>',
+                        '<div class="widget clr"><p class="tl_info">%s</p></div>',
                         $GLOBALS['TL_LANG']['tl_immoscout24_account']['api_explanation']
                     );
                 },
+            ],
+            'token_explanation' => [
+                'exclude' => true,
+                'input_field_callback' => static function () {
+                    return sprintf(
+                        '<div class="widget clr"><p class="tl_info">%s</p></div>',
+                        $GLOBALS['TL_LANG']['tl_immoscout24_account']['token_explanation']
+                    );
+                },
+            ],
+            'provision_access_token' => [
+                'exclude' => true,
+                'inputType' => 'checkbox',
+                'eval' => ['doNotSaveEmpty' => true, 'tl_class' => 'w50'],
+                'save_callback' => [
+                    // Do not save
+                    static function () {
+                        return null;
+                    },
+                ],
             ],
             'api_consumer_key' => [
                 'exclude' => true,
@@ -116,12 +137,12 @@ $GLOBALS['TL_DCA']['tl_immoscout24_account'] =
             'api_access_token' => [
                 'exclude' => true,
                 'inputType' => 'text',
-                'eval' => ['mandatory' => true, 'maxlength' => 255, 'tl_class' => 'w50', 'preserveTags' => true],
+                'eval' => ['maxlength' => 255, 'tl_class' => 'w50', 'preserveTags' => true],
             ],
             'api_access_token_secret' => [
                 'exclude' => true,
                 'inputType' => 'text',
-                'eval' => ['mandatory' => true, 'maxlength' => 255, 'tl_class' => 'w50', 'preserveTags' => true],
+                'eval' => ['maxlength' => 255, 'tl_class' => 'w50', 'preserveTags' => true],
             ],
             'enabled' => [
                 'exclude' => true,
@@ -133,12 +154,8 @@ $GLOBALS['TL_DCA']['tl_immoscout24_account'] =
                         return '1' === $value;
                     },
                 ],
+                // Keep this for MySQL Strict mode. Otherwise, Contao would save an empty string
+                'sql' => ['type' => 'boolean', 'default' => true],
             ],
-            //                'upload_directory' => [
-            //                        'label' => &$GLOBALS['TL_LANG']['tl_immoscout24_account']['upload_directory'],
-            //                        'exclude' => true,
-            //                        'inputType' => 'fileTree',
-            //                        'eval' => ['mandatory' => true, 'fieldType' => 'radio'],
-            //                    ],
         ],
     ];

--- a/src/Resources/contao/languages/en/tl_immoscout24_account.php
+++ b/src/Resources/contao/languages/en/tl_immoscout24_account.php
@@ -9,17 +9,29 @@ $GLOBALS['TL_LANG']['tl_immoscout24_account']['basic_legend'] = 'Account';
 $GLOBALS['TL_LANG']['tl_immoscout24_account']['description'] = ['Description'];
 
 $GLOBALS['TL_LANG']['tl_immoscout24_account']['credentials_legend'] = 'API Credentials';
+$GLOBALS['TL_LANG']['tl_immoscout24_account']['api_consumer_key'] = ['Consumer Key', 'System Key / Consumer Key'];
+$GLOBALS['TL_LANG']['tl_immoscout24_account']['api_consumer_secret'] = ['Consumer Secret', 'API Secret / Consumer Secret'];
 $GLOBALS['TL_LANG']['tl_immoscout24_account']['api_explanation'] =
     <<<'TAG'
-Enter your API credentials like you got them from Immoscout24.<br>
-Use the <a style="text-decoration: underline;" href="https://playground.immobilienscout24.de/rest/playground">API Playground</a> and follow the 
-<a style="text-decoration: underline;" href="https://api.immobilienscout24.de/useful/tutorials-sdks-plugins/tutorial-customer-website.html#playground">tutorial</a>
-to obtain a never expiring access token.
+Enter your API credentials like you got them from Immoscout24.<br><br>
+If you do not have credentials yet, head over to <a style="text-decoration: underline;" href="https://api.immobilienscout24.de">https://api.immobilienscout24.de</a>, log in,
+select <i>Manage Access</i> and create a new API project. Make sure to choose access for the <i>production</i> environment.
+Then copy the new <i>Consumer Key</i> and <i>Consumer Secret</i> into the following fields.
 TAG;
-$GLOBALS['TL_LANG']['tl_immoscout24_account']['api_consumer_key'] = ['Consumer Key'];
-$GLOBALS['TL_LANG']['tl_immoscout24_account']['api_consumer_secret'] = ['Consumer Secret'];
+
+$GLOBALS['TL_LANG']['tl_immoscout24_account']['token_legend'] = 'Long-lived Access Token';
 $GLOBALS['TL_LANG']['tl_immoscout24_account']['api_access_token'] = ['Access Token'];
 $GLOBALS['TL_LANG']['tl_immoscout24_account']['api_access_token_secret'] = ['Access Token Secret'];
+$GLOBALS['TL_LANG']['tl_immoscout24_account']['provision_access_token'] = ['Provision Access Token', 'Start the provisioning process when saving the record.'];
+$GLOBALS['TL_LANG']['tl_immoscout24_account']['token_explanation'] =
+    <<<'TAG'
+If you do not have a long-lived API token yet, you can tick the following checkbox to start the provisioning process when saving.<br><br>
+You will be redirected to the Immoscout24 website where you need to grant access for the consumer key you entered above.
+If successful, this account record will automatically be updated with a new access token and access token secret.
+TAG;
+$GLOBALS['TL_LANG']['tl_immoscout24_account']['access_token_error_1'] = 'Provisioning error: Could not authenticate with the given consumer key and secret. Please make sure this key has access to the production environment.';
+$GLOBALS['TL_LANG']['tl_immoscout24_account']['access_token_error_2'] = 'Provisioning error: Verification failed. Could not generate long-lived token credentials.';
+$GLOBALS['TL_LANG']['tl_immoscout24_account']['access_token_success'] = 'Provisioning successful. The account has been updated with new access token credentials.';
 
 $GLOBALS['TL_LANG']['tl_immoscout24_account']['sync_legend'] = 'Synchronization';
 $GLOBALS['TL_LANG']['tl_immoscout24_account']['enabled'] = ['Enable', 'Include this account in the synchronization when the sync command is executed.'];


### PR DESCRIPTION
This should now be super easy to get an access token. :slightly_smiling_face: 

Usage is basically this:

1. Get API credentials (consumer key & secret) from https://api.immoscout24.de
1. Open the `Immoscout24 Accounts` section in the back end
1. Enter the consumer key + secret and tick the `Provision Access Token` checkbox.
1. Hit save, click to confirm the key when redirected.
1. You're ready to go.

![Screenshot_20210923_142811](https://user-images.githubusercontent.com/5305677/134506661-f36fbae5-37fd-4a12-b384-648057f749bd.png)

All the heavy lifting is done under the hood. No need to copy, paste or convert stuff in Postman.